### PR TITLE
unittest drop_rels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ lxml>=4.9.0
 mock>=4.0.3
 pyparsing>=2.4.7
 pytest>=6.2.5
+pytest-mock>=3.7.0

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -17,7 +17,7 @@ from docx.image.tiff import Tiff
 from docx.opc.constants import CONTENT_TYPE as CT
 from docx.shared import Emu, Length
 
-from ..unitutil.file import test_file
+from ..unitutil.file import testfile
 from ..unitutil.mock import (
     ANY,
     class_mock,
@@ -121,7 +121,7 @@ class DescribeImage(object):
         ext, content_type, px_width, px_height, horz_dpi, vert_dpi = (
             characteristics
         )
-        with open(test_file(image_path), 'rb') as stream:
+        with open(testfile(image_path), 'rb') as stream:
             image = Image.from_file(stream)
             assert image.content_type == content_type
             assert image.ext == ext
@@ -154,7 +154,7 @@ class DescribeImage(object):
 
     @pytest.fixture
     def from_filelike_fixture(self, _from_stream_, image_):
-        image_path = test_file('python-icon.png')
+        image_path = testfile('python-icon.png')
         with open(image_path, 'rb') as f:
             blob = f.read()
         image_stream = BytesIO(blob)
@@ -163,7 +163,7 @@ class DescribeImage(object):
     @pytest.fixture
     def from_path_fixture(self, _from_stream_, BytesIO_, stream_, image_):
         filename = 'python-icon.png'
-        image_path = test_file(filename)
+        image_path = testfile(filename)
         with open(image_path, 'rb') as f:
             blob = f.read()
         return image_path, _from_stream_, stream_, blob, filename, image_
@@ -296,7 +296,7 @@ class Describe_ImageHeaderFactory(object):
     ])
     def call_fixture(self, request):
         image_filename, expected_class = request.param
-        image_path = test_file(image_filename)
+        image_path = testfile(image_filename)
         with open(image_path, 'rb') as f:
             blob = f.read()
         image_stream = BytesIO(blob)

--- a/tests/opc/test_part.py
+++ b/tests/opc/test_part.py
@@ -2,31 +2,24 @@
 
 """Unit test suite for docx.opc.part module"""
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 import pytest
 
 from docx.opc.package import OpcPackage
 from docx.opc.packuri import PackURI
 from docx.opc.part import Part, PartFactory, XmlPart
-from docx.opc.rel import _Relationship, Relationships
+from docx.opc.rel import Relationships, _Relationship
 from docx.oxml.xmlchemy import BaseOxmlElement
 
 from ..unitutil.cxml import element
-from ..unitutil.mock import (
-    ANY,
-    class_mock,
-    cls_attr_mock,
-    function_mock,
-    initializer_mock,
-    instance_mock,
-    loose_mock,
-    Mock,
-)
+from ..unitutil.mock import (ANY, Mock, class_mock, cls_attr_mock,
+                             function_mock, initializer_mock, instance_mock,
+                             loose_mock)
 
 
 class DescribePart(object):
-
     def it_can_be_constructed_by_PartFactory(
         self, partname_, content_type_, blob_, package_, __init_
     ):
@@ -71,7 +64,7 @@ class DescribePart(object):
 
     @pytest.fixture
     def content_type_fixture(self):
-        content_type = 'content/type'
+        content_type = "content/type"
         part = Part(None, content_type, None, None)
         return part, content_type
 
@@ -82,19 +75,18 @@ class DescribePart(object):
 
     @pytest.fixture
     def part(self):
-        part = Part(None, None)
-        return part
+        return Part(None, None)
 
     @pytest.fixture
     def partname_get_fixture(self):
-        partname = PackURI('/part/name')
+        partname = PackURI("/part/name")
         part = Part(partname, None, None, None)
         return part, partname
 
     @pytest.fixture
     def partname_set_fixture(self):
-        old_partname = PackURI('/old/part/name')
-        new_partname = PackURI('/new/part/name')
+        old_partname = PackURI("/old/part/name")
+        new_partname = PackURI("/new/part/name")
         part = Part(old_partname, None, None, None)
         return part, new_partname
 
@@ -122,7 +114,6 @@ class DescribePart(object):
 
 
 class DescribePartRelationshipManagementInterface(object):
-
     def it_provides_access_to_its_relationships(self, rels_fixture):
         part, Relationships_, partname_, rels_ = rels_fixture
         rels = part.rels
@@ -132,19 +123,15 @@ class DescribePartRelationshipManagementInterface(object):
     def it_can_load_a_relationship(self, load_rel_fixture):
         part, rels_, reltype_, target_, rId_ = load_rel_fixture
         part.load_rel(reltype_, target_, rId_)
-        rels_.add_relationship.assert_called_once_with(
-            reltype_, target_, rId_, False
-        )
+        rels_.add_relationship.assert_called_once_with(reltype_, target_, rId_, False)
 
-    def it_can_establish_a_relationship_to_another_part(
-            self, relate_to_part_fixture):
+    def it_can_establish_a_relationship_to_another_part(self, relate_to_part_fixture):
         part, target_, reltype_, rId_ = relate_to_part_fixture
         rId = part.relate_to(target_, reltype_)
         part.rels.get_or_add.assert_called_once_with(reltype_, target_)
         assert rId is rId_
 
-    def it_can_establish_an_external_relationship(
-            self, relate_to_url_fixture):
+    def it_can_establish_an_external_relationship(self, relate_to_url_fixture):
         part, url_, reltype_, rId_ = relate_to_url_fixture
         rId = part.relate_to(url_, reltype_, is_external=True)
         part.rels.get_or_add_ext_rel.assert_called_once_with(reltype_, url_)
@@ -168,22 +155,23 @@ class DescribePartRelationshipManagementInterface(object):
         part, related_parts_ = related_parts_fixture
         assert part.related_parts is related_parts_
 
-    def it_can_find_the_uri_of_an_external_relationship(
-            self, target_ref_fixture):
+    def it_can_find_the_uri_of_an_external_relationship(self, target_ref_fixture):
         part, rId_, url_ = target_ref_fixture
         url = part.target_ref(rId_)
         assert url == url_
 
     # fixtures ---------------------------------------------
 
-    @pytest.fixture(params=[
-        ('w:p', True),
-        ('w:p/r:a{r:id=rId42}', True),
-        ('w:p/r:a{r:id=rId42}/r:b{r:id=rId42}', False),
-    ])
+    @pytest.fixture(
+        params=[
+            ("w:p", True),
+            ("w:p/r:a{r:id=rId42}", True),
+            ("w:p/r:a{r:id=rId42}/r:b{r:id=rId42}", False),
+        ]
+    )
     def drop_rel_fixture(self, request, part):
         part_cxml, rel_should_be_dropped = request.param
-        rId = 'rId42'
+        rId = "rId42"
         part._element = element(part_cxml)
         part._rels = {rId: None}
         return part, rId, rel_should_be_dropped
@@ -194,15 +182,13 @@ class DescribePartRelationshipManagementInterface(object):
         return part, rels_, reltype_, part_, rId_
 
     @pytest.fixture
-    def relate_to_part_fixture(
-            self, request, part, reltype_, part_, rels_, rId_):
+    def relate_to_part_fixture(self, request, part, reltype_, part_, rels_, rId_):
         part._rels = rels_
         target_ = part_
         return part, target_, reltype_, rId_
 
     @pytest.fixture
-    def relate_to_url_fixture(
-            self, request, part, rels_, url_, reltype_, rId_):
+    def relate_to_url_fixture(self, request, part, rels_, url_, reltype_, rId_):
         part._rels = rels_
         return part, url_, reltype_, rId_
 
@@ -242,15 +228,11 @@ class DescribePartRelationshipManagementInterface(object):
 
     @pytest.fixture
     def Relationships_(self, request, rels_):
-        return class_mock(
-            request, 'docx.opc.part.Relationships', return_value=rels_
-        )
+        return class_mock(request, "docx.opc.part.Relationships", return_value=rels_)
 
     @pytest.fixture
     def rel_(self, request, rId_, url_):
-        return instance_mock(
-            request, _Relationship, rId=rId_, target_ref=url_
-        )
+        return instance_mock(request, _Relationship, rId=rId_, target_ref=url_)
 
     @pytest.fixture
     def rels_(self, request, part_, rel_, rId_, related_parts_):
@@ -279,12 +261,14 @@ class DescribePartRelationshipManagementInterface(object):
 
 
 class DescribePartFactory(object):
-
-    def it_constructs_part_from_selector_if_defined(
-            self, cls_selector_fixture):
+    def it_constructs_part_from_selector_if_defined(self, cls_selector_fixture):
         # fixture ----------------------
-        (cls_selector_fn_, part_load_params, CustomPartClass_,
-         part_of_custom_type_) = cls_selector_fixture
+        (
+            cls_selector_fn_,
+            part_load_params,
+            CustomPartClass_,
+            part_of_custom_type_,
+        ) = cls_selector_fixture
         partname, content_type, reltype, blob, package = part_load_params
         # exercise ---------------------
         PartFactory.part_class_selector = cls_selector_fn_
@@ -297,7 +281,8 @@ class DescribePartFactory(object):
         assert part is part_of_custom_type_
 
     def it_constructs_custom_part_type_for_registered_content_types(
-            self, part_args_, CustomPartClass_, part_of_custom_type_):
+        self, part_args_, CustomPartClass_, part_of_custom_type_
+    ):
         # fixture ----------------------
         partname, content_type, reltype, package, blob = part_args_
         # exercise ---------------------
@@ -310,7 +295,8 @@ class DescribePartFactory(object):
         assert part is part_of_custom_type_
 
     def it_constructs_part_using_default_class_when_no_custom_registered(
-            self, part_args_2_, DefaultPartClass_, part_of_default_type_):
+        self, part_args_2_, DefaultPartClass_, part_of_default_type_
+    ):
         partname, content_type, reltype, blob, package = part_args_2_
         part = PartFactory(partname, content_type, reltype, blob, package)
         DefaultPartClass_.load.assert_called_once_with(
@@ -331,21 +317,29 @@ class DescribePartFactory(object):
     @pytest.fixture
     def cls_method_fn_(self, request, cls_selector_fn_):
         return function_mock(
-            request, 'docx.opc.part.cls_method_fn',
-            return_value=cls_selector_fn_
+            request, "docx.opc.part.cls_method_fn", return_value=cls_selector_fn_
         )
 
     @pytest.fixture
     def cls_selector_fixture(
-            self, request, cls_selector_fn_, cls_method_fn_, part_load_params,
-            CustomPartClass_, part_of_custom_type_):
+        self,
+        request,
+        cls_selector_fn_,
+        cls_method_fn_,
+        part_load_params,
+        CustomPartClass_,
+        part_of_custom_type_,
+    ):
         def reset_part_class_selector():
             PartFactory.part_class_selector = original_part_class_selector
+
         original_part_class_selector = PartFactory.part_class_selector
         request.addfinalizer(reset_part_class_selector)
         return (
-            cls_selector_fn_, part_load_params, CustomPartClass_,
-            part_of_custom_type_
+            cls_selector_fn_,
+            part_load_params,
+            CustomPartClass_,
+            part_of_custom_type_,
         )
 
     @pytest.fixture
@@ -355,7 +349,7 @@ class DescribePartFactory(object):
         cls_selector_fn_.return_value = CustomPartClass_
         # Python 2 version
         cls_selector_fn_.__func__ = loose_mock(
-            request, name='__func__', return_value=cls_selector_fn_
+            request, name="__func__", return_value=cls_selector_fn_
         )
         return cls_selector_fn_
 
@@ -369,15 +363,13 @@ class DescribePartFactory(object):
 
     @pytest.fixture
     def CustomPartClass_(self, request, part_of_custom_type_):
-        CustomPartClass_ = Mock(name='CustomPartClass', spec=Part)
+        CustomPartClass_ = Mock(name="CustomPartClass", spec=Part)
         CustomPartClass_.load.return_value = part_of_custom_type_
         return CustomPartClass_
 
     @pytest.fixture
     def DefaultPartClass_(self, request, part_of_default_type_):
-        DefaultPartClass_ = cls_attr_mock(
-            request, PartFactory, 'default_part_type'
-        )
+        DefaultPartClass_ = cls_attr_mock(request, PartFactory, "default_part_type")
         DefaultPartClass_.load.return_value = part_of_default_type_
         return DefaultPartClass_
 
@@ -390,8 +382,7 @@ class DescribePartFactory(object):
         return instance_mock(request, OpcPackage)
 
     @pytest.fixture
-    def part_load_params(
-            self, partname_, content_type_, reltype_, blob_, package_):
+    def part_load_params(self, partname_, content_type_, reltype_, blob_, package_):
         return partname_, content_type_, reltype_, blob_, package_
 
     @pytest.fixture
@@ -411,15 +402,13 @@ class DescribePartFactory(object):
         return instance_mock(request, PackURI)
 
     @pytest.fixture
-    def part_args_(
-            self, request, partname_, content_type_, reltype_, package_,
-            blob_):
+    def part_args_(self, request, partname_, content_type_, reltype_, package_, blob_):
         return partname_, content_type_, reltype_, blob_, package_
 
     @pytest.fixture
     def part_args_2_(
-            self, request, partname_2_, content_type_2_, reltype_2_,
-            package_2_, blob_2_):
+        self, request, partname_2_, content_type_2_, reltype_2_, package_2_, blob_2_
+    ):
         return partname_2_, content_type_2_, reltype_2_, blob_2_, package_2_
 
     @pytest.fixture
@@ -432,7 +421,6 @@ class DescribePartFactory(object):
 
 
 class DescribeXmlPart(object):
-
     def it_can_be_constructed_by_PartFactory(
         self, partname_, content_type_, blob_, package_, element_, parse_xml_, __init_
     ):
@@ -489,9 +477,7 @@ class DescribeXmlPart(object):
 
     @pytest.fixture
     def parse_xml_(self, request, element_):
-        return function_mock(
-            request, 'docx.opc.part.parse_xml', return_value=element_
-        )
+        return function_mock(request, "docx.opc.part.parse_xml", return_value=element_)
 
     @pytest.fixture
     def partname_(self, request):
@@ -499,6 +485,31 @@ class DescribeXmlPart(object):
 
     @pytest.fixture
     def serialize_part_xml_(self, request):
-        return function_mock(
-            request, 'docx.opc.part.serialize_part_xml'
+        return function_mock(request, "docx.opc.part.serialize_part_xml")
+
+
+class TestPart:
+    def test_drop_rels(self, part_with_rels):
+        def cmp(rel):
+            return rel.target_part == "target1"
+
+        ret = part_with_rels.drop_rels(cmp)
+        assert len(part_with_rels.rels) == 1
+        assert part_with_rels.rels["rId2"].target_part == "target2"
+        assert ret == ["rId1"]
+
+    @pytest.fixture
+    def part_with_rels(self, mocker, rels):
+        mocker.patch(
+            "docx.opc.part.Part.rels",
+            new_callable=mocker.PropertyMock,
+            return_value=rels,
         )
+        return Part("null", None)
+
+    @pytest.fixture
+    def rels(self):
+        rels = Relationships(None)
+        rels["rId1"] = _Relationship("rId1", "reltype1", "target1", "base1")
+        rels["rId2"] = _Relationship("rId2", "reltype2", "target2", "base2")
+        return rels

--- a/tests/opc/test_phys_pkg.py
+++ b/tests/opc/test_phys_pkg.py
@@ -19,45 +19,47 @@ from zipfile import ZIP_DEFLATED, ZipFile
 from docx.opc.exceptions import PackageNotFoundError
 from docx.opc.packuri import PACKAGE_URI, PackURI
 from docx.opc.phys_pkg import (
-    _DirPkgReader, PhysPkgReader, PhysPkgWriter, _ZipPkgReader, _ZipPkgWriter
+    _DirPkgReader,
+    PhysPkgReader,
+    PhysPkgWriter,
+    _ZipPkgReader,
+    _ZipPkgWriter,
 )
 
-from ..unitutil.file import absjoin, test_file_dir
+from ..unitutil.file import absjoin, testfile_dir
 from ..unitutil.mock import class_mock, loose_mock, Mock
 
 
-test_docx_path = absjoin(test_file_dir, 'test.docx')
-dir_pkg_path = absjoin(test_file_dir, 'expanded_docx')
+test_docx_path = absjoin(testfile_dir, "test.docx")
+dir_pkg_path = absjoin(testfile_dir, "expanded_docx")
 zip_pkg_path = test_docx_path
 
 
 class DescribeDirPkgReader(object):
-
     def it_is_used_by_PhysPkgReader_when_pkg_is_a_dir(self):
         phys_reader = PhysPkgReader(dir_pkg_path)
         assert isinstance(phys_reader, _DirPkgReader)
 
-    def it_doesnt_mind_being_closed_even_though_it_doesnt_need_it(
-            self, dir_reader):
+    def it_doesnt_mind_being_closed_even_though_it_doesnt_need_it(self, dir_reader):
         dir_reader.close()
 
     def it_can_retrieve_the_blob_for_a_pack_uri(self, dir_reader):
-        pack_uri = PackURI('/word/document.xml')
+        pack_uri = PackURI("/word/document.xml")
         blob = dir_reader.blob_for(pack_uri)
         sha1 = hashlib.sha1(blob).hexdigest()
-        assert sha1 == '0e62d87ea74ea2b8088fd11ee97b42da9b4c77b0'
+        assert sha1 == "0e62d87ea74ea2b8088fd11ee97b42da9b4c77b0"
 
     def it_can_get_the_content_types_xml(self, dir_reader):
         sha1 = hashlib.sha1(dir_reader.content_types_xml).hexdigest()
-        assert sha1 == '89aadbb12882dd3d7340cd47382dc2c73d75dd81'
+        assert sha1 == "89aadbb12882dd3d7340cd47382dc2c73d75dd81"
 
     def it_can_retrieve_the_rels_xml_for_a_source_uri(self, dir_reader):
         rels_xml = dir_reader.rels_xml_for(PACKAGE_URI)
         sha1 = hashlib.sha1(rels_xml).hexdigest()
-        assert sha1 == 'ebacdddb3e7843fdd54c2f00bc831551b26ac823'
+        assert sha1 == "ebacdddb3e7843fdd54c2f00bc831551b26ac823"
 
     def it_returns_none_when_part_has_no_rels_xml(self, dir_reader):
-        partname = PackURI('/ppt/viewProps.xml')
+        partname = PackURI("/ppt/viewProps.xml")
         rels_xml = dir_reader.rels_xml_for(partname)
         assert rels_xml is None
 
@@ -67,32 +69,30 @@ class DescribeDirPkgReader(object):
     def pkg_file_(self, request):
         return loose_mock(request)
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def dir_reader(self):
         return _DirPkgReader(dir_pkg_path)
 
 
 class DescribePhysPkgReader(object):
-
     def it_raises_when_pkg_path_is_not_a_package(self):
         with pytest.raises(PackageNotFoundError):
-            PhysPkgReader('foobar')
+            PhysPkgReader("foobar")
 
 
 class DescribeZipPkgReader(object):
-
     def it_is_used_by_PhysPkgReader_when_pkg_is_a_zip(self):
         phys_reader = PhysPkgReader(zip_pkg_path)
         assert isinstance(phys_reader, _ZipPkgReader)
 
     def it_is_used_by_PhysPkgReader_when_pkg_is_a_stream(self):
-        with open(zip_pkg_path, 'rb') as stream:
+        with open(zip_pkg_path, "rb") as stream:
             phys_reader = PhysPkgReader(stream)
         assert isinstance(phys_reader, _ZipPkgReader)
 
     def it_opens_pkg_file_zip_on_construction(self, ZipFile_, pkg_file_):
         _ZipPkgReader(pkg_file_)
-        ZipFile_.assert_called_once_with(pkg_file_, 'r')
+        ZipFile_.assert_called_once_with(pkg_file_, "r")
 
     def it_can_be_closed(self, ZipFile_):
         # mockery ----------------------
@@ -104,28 +104,28 @@ class DescribeZipPkgReader(object):
         zipf.close.assert_called_once_with()
 
     def it_can_retrieve_the_blob_for_a_pack_uri(self, phys_reader):
-        pack_uri = PackURI('/word/document.xml')
+        pack_uri = PackURI("/word/document.xml")
         blob = phys_reader.blob_for(pack_uri)
         sha1 = hashlib.sha1(blob).hexdigest()
-        assert sha1 == 'b9b4a98bcac7c5a162825b60c3db7df11e02ac5f'
+        assert sha1 == "b9b4a98bcac7c5a162825b60c3db7df11e02ac5f"
 
     def it_has_the_content_types_xml(self, phys_reader):
         sha1 = hashlib.sha1(phys_reader.content_types_xml).hexdigest()
-        assert sha1 == 'cd687f67fd6b5f526eedac77cf1deb21968d7245'
+        assert sha1 == "cd687f67fd6b5f526eedac77cf1deb21968d7245"
 
     def it_can_retrieve_rels_xml_for_source_uri(self, phys_reader):
         rels_xml = phys_reader.rels_xml_for(PACKAGE_URI)
         sha1 = hashlib.sha1(rels_xml).hexdigest()
-        assert sha1 == '90965123ed2c79af07a6963e7cfb50a6e2638565'
+        assert sha1 == "90965123ed2c79af07a6963e7cfb50a6e2638565"
 
     def it_returns_none_when_part_has_no_rels_xml(self, phys_reader):
-        partname = PackURI('/ppt/viewProps.xml')
+        partname = PackURI("/ppt/viewProps.xml")
         rels_xml = phys_reader.rels_xml_for(partname)
         assert rels_xml is None
 
     # fixtures ---------------------------------------------
 
-    @pytest.fixture(scope='class')
+    @pytest.fixture(scope="class")
     def phys_reader(self, request):
         phys_reader = _ZipPkgReader(zip_pkg_path)
         request.addfinalizer(phys_reader.close)
@@ -137,17 +137,14 @@ class DescribeZipPkgReader(object):
 
 
 class DescribeZipPkgWriter(object):
-
     def it_is_used_by_PhysPkgWriter_unconditionally(self, tmp_docx_path):
         phys_writer = PhysPkgWriter(tmp_docx_path)
         assert isinstance(phys_writer, _ZipPkgWriter)
 
     def it_opens_pkg_file_zip_on_construction(self, ZipFile_):
-        pkg_file = Mock(name='pkg_file')
+        pkg_file = Mock(name="pkg_file")
         _ZipPkgWriter(pkg_file)
-        ZipFile_.assert_called_once_with(
-            pkg_file, 'w', compression=ZIP_DEFLATED
-        )
+        ZipFile_.assert_called_once_with(pkg_file, "w", compression=ZIP_DEFLATED)
 
     def it_can_be_closed(self, ZipFile_):
         # mockery ----------------------
@@ -160,15 +157,15 @@ class DescribeZipPkgWriter(object):
 
     def it_can_write_a_blob(self, pkg_file):
         # setup ------------------------
-        pack_uri = PackURI('/part/name.xml')
-        blob = '<BlobbityFooBlob/>'.encode('utf-8')
+        pack_uri = PackURI("/part/name.xml")
+        blob = "<BlobbityFooBlob/>".encode("utf-8")
         # exercise ---------------------
         pkg_writer = PhysPkgWriter(pkg_file)
         pkg_writer.write(pack_uri, blob)
         pkg_writer.close()
         # verify -----------------------
         written_blob_sha1 = hashlib.sha1(blob).hexdigest()
-        zipf = ZipFile(pkg_file, 'r')
+        zipf = ZipFile(pkg_file, "r")
         retrieved_blob = zipf.read(pack_uri.membername)
         zipf.close()
         retrieved_blob_sha1 = hashlib.sha1(retrieved_blob).hexdigest()
@@ -185,11 +182,12 @@ class DescribeZipPkgWriter(object):
 
 # fixtures -------------------------------------------------
 
+
 @pytest.fixture
 def tmp_docx_path(tmpdir):
-    return str(tmpdir.join('test_python-docx.docx'))
+    return str(tmpdir.join("test_python-docx.docx"))
 
 
 @pytest.fixture
 def ZipFile_(request):
-    return class_mock(request, 'docx.opc.phys_pkg.ZipFile')
+    return class_mock(request, "docx.opc.phys_pkg.ZipFile")

--- a/tests/parts/test_image.py
+++ b/tests/parts/test_image.py
@@ -13,12 +13,11 @@ from docx.opc.part import PartFactory
 from docx.package import Package
 from docx.parts.image import ImagePart
 
-from ..unitutil.file import test_file
+from ..unitutil.file import testfile
 from ..unitutil.mock import ANY, initializer_mock, instance_mock, method_mock
 
 
 class DescribeImagePart(object):
-
     def it_is_used_by_PartFactory_to_construct_image_part(
         self, image_part_load_, partname_, blob_, package_, image_part_
     ):
@@ -51,9 +50,9 @@ class DescribeImagePart(object):
         assert image_part.filename == expected_filename
 
     def it_knows_the_sha1_of_its_image(self):
-        blob = b'fO0Bar'
+        blob = b"fO0Bar"
         image_part = ImagePart(None, None, blob)
-        assert image_part.sha1 == '4921e7002ddfba690a937d54bda226a7b8bdeb68'
+        assert image_part.sha1 == "4921e7002ddfba690a937d54bda226a7b8bdeb68"
 
     # fixtures -------------------------------------------------------
 
@@ -61,33 +60,31 @@ class DescribeImagePart(object):
     def blob_(self, request):
         return instance_mock(request, str)
 
-    @pytest.fixture(params=['loaded', 'new'])
+    @pytest.fixture(params=["loaded", "new"])
     def dimensions_fixture(self, request):
-        image_file_path = test_file('monty-truth.png')
+        image_file_path = testfile("monty-truth.png")
         image = Image.from_file(image_file_path)
         expected_cx, expected_cy = 1905000, 2717800
 
         # case 1: image part is loaded by PartFactory w/no Image inst
-        if request.param == 'loaded':
-            partname = PackURI('/word/media/image1.png')
+        if request.param == "loaded":
+            partname = PackURI("/word/media/image1.png")
             content_type = CT.PNG
-            image_part = ImagePart.load(
-                partname, content_type, image.blob, None
-            )
+            image_part = ImagePart.load(partname, content_type, image.blob, None)
         # case 2: image part is newly created from image file
-        elif request.param == 'new':
+        elif request.param == "new":
             image_part = ImagePart.from_image(image, None)
 
         return image_part, expected_cx, expected_cy
 
-    @pytest.fixture(params=['loaded', 'new'])
+    @pytest.fixture(params=["loaded", "new"])
     def filename_fixture(self, request, image_):
-        partname = PackURI('/word/media/image666.png')
-        if request.param == 'loaded':
+        partname = PackURI("/word/media/image666.png")
+        if request.param == "loaded":
             image_part = ImagePart(partname, None, None, None)
-            expected_filename = 'image.png'
-        elif request.param == 'new':
-            image_.filename = 'foobar.PXG'
+            expected_filename = "image.png"
+        elif request.param == "new":
+            image_.filename = "foobar.PXG"
             image_part = ImagePart(partname, None, None, image_)
             expected_filename = image_.filename
         return image_part, expected_filename
@@ -106,7 +103,7 @@ class DescribeImagePart(object):
 
     @pytest.fixture
     def image_part_load_(self, request):
-        return method_mock(request, ImagePart, 'load', autospec=False)
+        return method_mock(request, ImagePart, "load", autospec=False)
 
     @pytest.fixture
     def package_(self, request):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from docx.image.image import Image
+from docx.opc.package import OpcPackage
 from docx.opc.packuri import PackURI
-from docx.opc.part import Part
 from docx.opc.rel import Relationships, _Relationship
 from docx.package import ImageParts, Package
 from docx.parts.image import ImagePart
@@ -155,24 +155,24 @@ class DescribeImageParts(object):
         return instance_mock(request, PackURI)
 
 
-class TestPackage:
-    def test_drop_rels(self, part_with_rels):
+class TestOpcPackage:
+    def test_drop_rels(self, package_with_rels):
         def cmp(rel):
             return "2" in rel.reltype
 
-        ret = part_with_rels.drop_rels(cmp)
-        assert len(part_with_rels.rels) == 2
-        assert part_with_rels.rels["rId3"].reltype == "reltype3"
+        ret = package_with_rels.drop_rels(cmp)
+        assert len(package_with_rels.rels) == 2
+        assert package_with_rels.rels["rId3"].reltype == "reltype3"
         assert ret == ["rId2"]
 
     @pytest.fixture
-    def part_with_rels(self, mocker, rels):
+    def package_with_rels(self, mocker, rels):
         mocker.patch(
-            "docx.opc.part.Part.rels",
+            "docx.opc.package.OpcPackage.rels",
             new_callable=mocker.PropertyMock,
             return_value=rels,
         )
-        return Part("null", None)
+        return OpcPackage()
 
     @pytest.fixture
     def rels(self):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -8,6 +8,8 @@ import pytest
 
 from docx.image.image import Image
 from docx.opc.packuri import PackURI
+from docx.opc.part import Part
+from docx.opc.rel import Relationships, _Relationship
 from docx.package import ImageParts, Package
 from docx.parts.image import ImagePart
 
@@ -16,7 +18,6 @@ from .unitutil.mock import class_mock, instance_mock, method_mock, property_mock
 
 
 class DescribePackage(object):
-
     def it_can_get_or_add_an_image_part_containing_a_specified_image(
         self, image_parts_prop_, image_parts_, image_part_
     ):
@@ -30,7 +31,7 @@ class DescribePackage(object):
         assert image_part is image_part_
 
     def it_gathers_package_image_parts_after_unmarshalling(self):
-        package = Package.open(docx_path('having-images'))
+        package = Package.open(docx_path("having-images"))
         image_parts = package.image_parts
         assert len(image_parts) == 3
         for image_part in image_parts:
@@ -52,7 +53,6 @@ class DescribePackage(object):
 
 
 class DescribeImageParts(object):
-
     def it_can_get_a_matching_image_part(
         self, Image_, image_, _get_by_sha1_, image_part_
     ):
@@ -104,20 +104,19 @@ class DescribeImageParts(object):
 
     @pytest.fixture(params=[((2, 3), 1), ((1, 3), 2), ((1, 2), 3)])
     def next_partname_fixture(self, request):
-
         def image_part_with_partname_(n):
             partname = image_partname(n)
             return instance_mock(request, ImagePart, partname=partname)
 
         def image_partname(n):
-            return PackURI('/word/media/image%d.png' % n)
+            return PackURI("/word/media/image%d.png" % n)
 
         existing_partname_numbers, expected_partname_number = request.param
         image_parts = ImageParts()
         for n in existing_partname_numbers:
             image_part_ = image_part_with_partname_(n)
             image_parts.append(image_part_)
-        ext = 'png'
+        ext = "png"
         expected_image_partname = image_partname(expected_partname_number)
         return image_parts, ext, expected_image_partname
 
@@ -125,15 +124,15 @@ class DescribeImageParts(object):
 
     @pytest.fixture
     def _add_image_part_(self, request):
-        return method_mock(request, ImageParts, '_add_image_part')
+        return method_mock(request, ImageParts, "_add_image_part")
 
     @pytest.fixture
     def _get_by_sha1_(self, request):
-        return method_mock(request, ImageParts, '_get_by_sha1')
+        return method_mock(request, ImageParts, "_get_by_sha1")
 
     @pytest.fixture
     def Image_(self, request):
-        return class_mock(request, 'docx.package.Image')
+        return class_mock(request, "docx.package.Image")
 
     @pytest.fixture
     def image_(self, request):
@@ -141,7 +140,7 @@ class DescribeImageParts(object):
 
     @pytest.fixture
     def ImagePart_(self, request):
-        return class_mock(request, 'docx.package.ImagePart')
+        return class_mock(request, "docx.package.ImagePart")
 
     @pytest.fixture
     def image_part_(self, request):
@@ -149,8 +148,36 @@ class DescribeImageParts(object):
 
     @pytest.fixture
     def _next_image_partname_(self, request):
-        return method_mock(request, ImageParts, '_next_image_partname')
+        return method_mock(request, ImageParts, "_next_image_partname")
 
     @pytest.fixture
     def partname_(self, request):
         return instance_mock(request, PackURI)
+
+
+class TestPackage:
+    def test_drop_rels(self, part_with_rels):
+        def cmp(rel):
+            return "2" in rel.reltype
+
+        ret = part_with_rels.drop_rels(cmp)
+        assert len(part_with_rels.rels) == 2
+        assert part_with_rels.rels["rId3"].reltype == "reltype3"
+        assert ret == ["rId2"]
+
+    @pytest.fixture
+    def part_with_rels(self, mocker, rels):
+        mocker.patch(
+            "docx.opc.part.Part.rels",
+            new_callable=mocker.PropertyMock,
+            return_value=rels,
+        )
+        return Part("null", None)
+
+    @pytest.fixture
+    def rels(self):
+        rels = Relationships(None)
+        rels["rId1"] = _Relationship("rId1", "reltype1", "target1", "base1")
+        rels["rId2"] = _Relationship("rId2", "reltype2", "target2", "base2")
+        rels["rId3"] = _Relationship("rId3", "reltype3", "target3", "base3")
+        return rels

--- a/tests/unitutil/file.py
+++ b/tests/unitutil/file.py
@@ -8,7 +8,7 @@ import os
 
 
 _thisdir = os.path.split(__file__)[0]
-test_file_dir = os.path.abspath(os.path.join(_thisdir, '..', 'test_files'))
+testfile_dir = os.path.abspath(os.path.join(_thisdir, "..", "test_files"))
 
 
 def abspath(relpath):
@@ -24,7 +24,7 @@ def docx_path(name):
     """
     Return the absolute path to test .docx file with root name *name*.
     """
-    return absjoin(test_file_dir, '%s.docx' % name)
+    return absjoin(testfile_dir, "%s.docx" % name)
 
 
 def snippet_seq(name, offset=0, count=1024):
@@ -33,11 +33,11 @@ def snippet_seq(name, offset=0, count=1024):
     file having *name*. Snippets are delimited by a blank line. If specified,
     *count* snippets starting at *offset* are returned.
     """
-    path = os.path.join(test_file_dir, 'snippets', '%s.txt' % name)
-    with open(path, 'rb') as f:
-        text = f.read().decode('utf-8')
-    snippets = text.split('\n\n')
-    start, end = offset, offset+count
+    path = os.path.join(testfile_dir, "snippets", "%s.txt" % name)
+    with open(path, "rb") as f:
+        text = f.read().decode("utf-8")
+    snippets = text.split("\n\n")
+    start, end = offset, offset + count
     return tuple(snippets[start:end])
 
 
@@ -47,15 +47,15 @@ def snippet_text(snippet_file_name):
     *snippet_file_name*.
     """
     snippet_file_path = os.path.join(
-        test_file_dir, 'snippets', '%s.txt' % snippet_file_name
+        testfile_dir, "snippets", "%s.txt" % snippet_file_name
     )
-    with open(snippet_file_path, 'rb') as f:
+    with open(snippet_file_path, "rb") as f:
         snippet_bytes = f.read()
-    return snippet_bytes.decode('utf-8')
+    return snippet_bytes.decode("utf-8")
 
 
-def test_file(name):
+def testfile(name):
     """
     Return the absolute path to test file having *name*.
     """
-    return absjoin(test_file_dir, name)
+    return absjoin(testfile_dir, name)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ max-line-length = 88
 norecursedirs = doc docx *.egg-info features .git ref _scratch .tox
 python_files = test_*.py
 python_classes = Test Describe
-python_functions = it_ they_ and_it_ but_it_
+python_functions = it_ they_ and_it_ but_it_ test_
 
 [tox]
 envlist = py38, py39, py310
@@ -20,6 +20,7 @@ deps =
     lxml
     pyparsing
     pytest
+    pytest-mock
 
 commands =
     pytest -qx


### PR DESCRIPTION
- add unittest function suffix `test_`
- change `test_file` to `testfile`
- TestOpcPackage.test_drop_rels
- TestPart.test_drop_rels