### PR TITLE
change method text to texts in CT_R

### DIFF
--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -1,9 +1,6 @@
-# encoding: utf-8
-
 """
 Custom element classes related to text runs (CT_R).
 """
-
 from ..ns import qn
 from ..simpletypes import ST_BrClear, ST_BrType
 from ..xmlchemy import BaseOxmlElement, OptionalAttribute, ZeroOrMore, ZeroOrOne
@@ -81,7 +78,7 @@ class CT_R(BaseOxmlElement):
         rPr.style = style
 
     @property
-    def text(self):
+    def texts(self):
         """
         A string representing the textual content of this run, with content
         child elements like ``<w:tab/>`` translated to their Python
@@ -98,8 +95,8 @@ class CT_R(BaseOxmlElement):
                 text += "\n"
         return text
 
-    @text.setter
-    def text(self, text):
+    @texts.setter
+    def texts(self, text):
         self.clear_content()
         _RunContentAppender.append_to_run_from_text(self, text)
 

--- a/docx/table.py
+++ b/docx/table.py
@@ -1,15 +1,10 @@
-# encoding: utf-8
-
 """
 The |Table| object and related proxy classes.
 """
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 from .blkcntnr import BlockItemContainer
 from .enum.style import WD_STYLE_TYPE
 from .oxml.simpletypes import ST_Merge
-from .shared import Inches, lazyproperty, Parented
+from .shared import Inches, Parented, lazyproperty
 
 
 class Table(Parented):
@@ -266,7 +261,7 @@ class _Cell(BlockItemContainer):
         tc.clear_content()
         p = tc.add_p()
         r = p.add_r()
-        r.text = text
+        r.texts = text
 
     @property
     def vertical_alignment(self):

--- a/docx/text/run.py
+++ b/docx/text/run.py
@@ -1,16 +1,11 @@
-# encoding: utf-8
-
 """
 Run-related proxy objects for python-docx, Run in particular.
 """
-
-from __future__ import absolute_import, print_function, unicode_literals
-
 from ..enum.style import WD_STYLE_TYPE
 from ..enum.text import WD_BREAK
-from .font import Font
 from ..shape import InlineShape
 from ..shared import Parented
+from .font import Font
 
 
 class Run(Parented):
@@ -155,11 +150,11 @@ class Run(Parented):
         ``\\r`` character to a ``<w:cr/>`` element. Any existing run content
         is replaced. Run formatting is preserved.
         """
-        return self._r.text
+        return self._r.texts
 
     @text.setter
     def text(self, text):
-        self._r.text = text
+        self._r.texts = text
 
     @property
     def underline(self):

--- a/tests/oxml/text/test_run.py
+++ b/tests/oxml/text/test_run.py
@@ -41,6 +41,11 @@ class TestCT_R:
         element, ret = itertext_item
         assert "".join(element.itertext()) == ret
 
+    def load_params(self, request):
+        xml, expected_text = request.param
+        ctr = element(xml)
+        return ctr, expected_text
+
     @pytest.fixture(
         params=[
             ('w:r/w:t"foobar"', "foobar"),
@@ -48,9 +53,7 @@ class TestCT_R:
         ]
     )
     def itertext_item(self, request):
-        xml, expected_text = request.param
-        ctr = element(xml)
-        return ctr, expected_text
+        return self.load_params(request)
 
     @pytest.fixture(
         params=[
@@ -59,6 +62,4 @@ class TestCT_R:
         ]
     )
     def texts_item(self, request):
-        xml, expected_text = request.param
-        ctr = element(xml)
-        return ctr, expected_text
+        return self.load_params(request)

--- a/tests/oxml/text/test_run.py
+++ b/tests/oxml/text/test_run.py
@@ -1,11 +1,6 @@
-# encoding: utf-8
-
 """
 Test suite for the docx.oxml.text.run module.
 """
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import pytest
 
 from ...unitutil.cxml import element, xml
@@ -35,3 +30,35 @@ class DescribeCT_R(object):
         r = element(initial_cxml)
         expected_xml = xml(expected_cxml)
         return r, text, expected_xml
+
+
+class TestCT_R:
+    def test_texts(self, texts_item):
+        element, ret = texts_item
+        assert element.texts == ret
+
+    def test_itertext(self, itertext_item):
+        element, ret = itertext_item
+        assert "".join(element.itertext()) == ret
+
+    @pytest.fixture(
+        params=[
+            ('w:r/w:t"foobar"', "foobar"),
+            ('w:r/(w:t"abc", w:tab, w:t"def", w:cr)', "abcdef"),
+        ]
+    )
+    def itertext_item(self, request):
+        xml, expected_text = request.param
+        ctr = element(xml)
+        return ctr, expected_text
+
+    @pytest.fixture(
+        params=[
+            ('w:r/w:t"foobar"', "foobar"),
+            ('w:r/(w:t"abc", w:tab, w:t"def", w:cr)', "abc\tdef\n"),
+        ]
+    )
+    def texts_item(self, request):
+        xml, expected_text = request.param
+        ctr = element(xml)
+        return ctr, expected_text


### PR DESCRIPTION
Method _text_ in class _CT_R_ will duplicate the result of _itertext_, so change the name to _texts_.