### PR TITLE
change default custom xml file name to item1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,11 @@
 Release History
 ---------------
 
+**0.0.6 (2022-10-21)**
+
+- change default custom xml file name to item1.
+
+
 **0.0.5 (2022-8-08)**
 
 - minor refactor custom-properties

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,13 +3,13 @@ Release History
 
 **0.0.6 (2022-10-21)**
 
-- change default custom xml file name to item1.
+- change default custom xml file name to item1. #23
 
 
 **0.0.5 (2022-8-08)**
 
-- minor refactor custom-properties
-- add add_float_picture in Document #21
+- minor refactor custom-properties.
+- add add_float_picture in Document. #21
 
 
 **0.0.4 (2022-7-21)**

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -1,6 +1,6 @@
 from docx.api import Document  # noqa
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 
 # register custom Part classes with opc package reader

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -1,6 +1,6 @@
 from docx.api import Document  # noqa
 
-__version__ = "0.0.6"
+__version__ = "0.0.6rc2"
 
 
 # register custom Part classes with opc package reader

--- a/docx/parts/document.py
+++ b/docx/parts/document.py
@@ -63,7 +63,7 @@ class DocumentPart(BaseStoryPart):
             return []
 
     def add_custom_xml_part(
-        self, xml: str, file_name: str = "item", content_type: str = CT.XML
+        self, xml: str, file_name: str = "item1", content_type: str = CT.XML
     ) -> CustomXmlPart:
         """
         Add a file in /customXml/*file_name*.xml with default content *xml*

--- a/docx/parts/story.py
+++ b/docx/parts/story.py
@@ -61,7 +61,6 @@ class BaseStoryPart(XmlPart):
         """
         rId, image = self.get_or_add_image(image_descriptor)
         cx, cy = image.scaled_dimensions(width, height)
-        print(width, height, cx, cy)
         shape_id, filename = self.next_id, image.filename
         return CT_Anchor.new_pic_anchor(shape_id, rId, filename, cx, cy, pos_x, pos_y)
 


### PR DESCRIPTION
It may cause data lost using the name 'item' in some versions of Word.